### PR TITLE
Fix minor typo in 'ghost' win case.

### DIFF
--- a/ipynb/Ghost.ipynb
+++ b/ipynb/Ghost.ipynb
@@ -431,7 +431,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "**Yes.** The first player can win with this vocabulary, by playing `'h'` first (and there might be other first plays that also force a win). It makes sense that it is easier for the first player to win, because we've eliminated a bunch of three-letter words from the vocabulary, all of which are losers for the first player. So here's a good meta-strategy: Say \"*Hey, let's play a game of Ghost. We can use the `enable1` word list. Would you like the limit to be 3 or 4 letters?*\" Then if your opponent says three (or four) you can say \"*OK, since you decided that, I'll decide to go second (or first).*\""
+    "**Yes.** The first player can win with this vocabulary, by playing `'n'` first (and there might be other first plays that also force a win). It makes sense that it is easier for the first player to win, because we've eliminated a bunch of three-letter words from the vocabulary, all of which are losers for the first player. So here's a good meta-strategy: Say \"*Hey, let's play a game of Ghost. We can use the `enable1` word list. Would you like the limit to be 3 or 4 letters?*\" Then if your opponent says three (or four) you can say \"*OK, since you decided that, I'll decide to go second (or first).*\""
    ]
   },
   {


### PR DESCRIPTION
The explanation after `out[17]: n` had 'h' as a forced win case. This fixed the minor typo.