### PR TITLE
Fix unit tests for Spelling Corrector

### DIFF
--- a/py/spell.py
+++ b/py/spell.py
@@ -58,20 +58,20 @@ def unit_tests():
     assert words('This is a TEST.') == ['this', 'is', 'a', 'test']
     assert Counter(words('This is a test. 123; A TEST this is.')) == (
            Counter({'123': 1, 'a': 2, 'is': 2, 'test': 2, 'this': 2}))
-    assert len(WORDS) == 32192
-    assert sum(WORDS.values()) == 1115504
+    assert len(WORDS) == 32198
+    assert sum(WORDS.values()) == 1115585
     assert WORDS.most_common(10) == [
-     ('the', 79808),
+     ('the', 79809),
      ('of', 40024),
-     ('and', 38311),
+     ('and', 38312),
      ('to', 28765),
-     ('in', 22020),
+     ('in', 22023),
      ('a', 21124),
      ('that', 12512),
      ('he', 12401),
      ('was', 11410),
      ('it', 10681)]
-    assert WORDS['the'] == 79808
+    assert WORDS['the'] == 79809
     assert P('quintessential') == 0
     assert 0.07 < P('the') < 0.08
     return 'unit_tests pass'


### PR DESCRIPTION
Using Python 3.6 I got some errors in the _Spelling Corrector unit tests_. This was using your latest http://norvig.com/big.txt file:

```bash
$ python spell.py
Traceback (most recent call last):
  File "spell.py", line 104, in <module>
    print(unit_tests())
  File "spell.py", line 61, in unit_tests
    assert len(WORDS) == 32192
AssertionError
```

This PR should fix all those errors:

```bash
$ python spell.py
unit_tests pass
75% of 270 correct (6% unknown) at 21 words per second
68% of 400 correct (11% unknown) at 18 words per second
```

HTH