### PR TITLE
Typos on ipynb/PropositionalLogic.ipynb

### DIFF
--- a/ipynb/PropositionalLogic.ipynb
+++ b/ipynb/PropositionalLogic.ipynb
@@ -129,7 +129,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now the mechanism to process these rules. The key function is `match_rule`, which matches an English sentence against a rule. The function returns two values, a string representing the translation of the Eng;lish sentence into logic, and `defs`, a dictionary of `{Variable: \"value\"}` pairs. If `match_rule` finds that the rule matches, it recursively calls `match_rules` to match each of the subgroups of the regular expression (the `P` and `Q` in `if {P}, then {Q}`).\n",
+    "Now the mechanism to process these rules. The key function is `match_rule`, which matches an English sentence against a rule. The function returns two values, a string representing the translation of the English sentence into logic, and `defs`, a dictionary of `{Variable: \"value\"}` pairs. If `match_rule` finds that the rule matches, it recursively calls `match_rules` to match each of the subgroups of the regular expression (the `P` and `Q` in `if {P}, then {Q}`).\n",
     "The function `match_literal` handles negations, and is where the `defs` dictionary actually gets updated."
    ]
   },

--- a/ipynb/PropositionalLogic.ipynb
+++ b/ipynb/PropositionalLogic.ipynb
@@ -435,7 +435,7 @@
    "source": [
     "That looks pretty good! But far from perfect.  Here are some errors:\n",
     "\n",
-    "* `Should I stay` *etc.*:<br>questions are not poropositional statements.\n",
+    "* `Should I stay` *etc.*:<br>questions are not propositional statements.\n",
     "\n",
     "* `If I were a carpenter`:<br>doesn't handle modal logic.\n",
     "\n",


### PR DESCRIPTION
Typo: `poropositional` → `propositional`
Typo: `Eng;lish` → `English`