### PR TITLE
Typo: infortative → informative on ipynb/BASIC.ipynb

### DIFF
--- a/ipynb/BASIC.ipynb
+++ b/ipynb/BASIC.ipynb
@@ -1737,7 +1737,7 @@
     "# Final Program\n",
     "\n",
     "Now for a final, longer example, Conway's Game of [Life](https://en.wikipedia.org/wiki/Conway's_Game_of_Life),\n",
-    "which shows that BASIC is capable of handling a non-trivial problem&mdash;but I wouldn't want to rely on it for anything much bigger. This should give us some added confidence in the validity of the interpreter, but I would say the interpreter needs more work before I would trust it. I hope you found working through the interpreter infortative, and maybe you have ideas for how to improve it, or to develop an interpreter for another language."
+    "which shows that BASIC is capable of handling a non-trivial problem&mdash;but I wouldn't want to rely on it for anything much bigger. This should give us some added confidence in the validity of the interpreter, but I would say the interpreter needs more work before I would trust it. I hope you found working through the interpreter informative, and maybe you have ideas for how to improve it, or to develop an interpreter for another language."
    ]
   },
   {
@@ -1931,15 +1931,6 @@
     "999 END \n",
     "''')"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
- Typo: `infortative` → `informative`
- Remove last empty cell