### PR TITLE
Typo: alohabetically → alphabetically on Gesture Typing.ipynb

### DIFF
--- a/ipynb/Gesture Typing.ipynb
+++ b/ipynb/Gesture Typing.ipynb
@@ -400,7 +400,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "And the longest ten paths? Including the lengths? We'll use a helper function, `print_top`, which prints the top *n* items in a seqence according to some key function:"
+    "And the ten longest paths? Including the lengths? We'll use a helper function, `print_top`, which prints the top *n* items in a seqence according to some key function:"
    ]
   },
   {
@@ -490,7 +490,7 @@
     "===\n",
     "\n",
     "What is the average segment length for a typical typing work load? To answer that, we need to know what a typical work load is. We will read a file of \"typical\" text, and count how many times each segment is used. A `Workload` is a `dict` of the form `{segment: proportion, ...},` e.g. `{'AB': 0.02}`, where each key is a two-letter string (or *bigram*) representing a segment, and each value is the proportion of time that segment appears in the workload.  Since the distance from `A` to `B` on a keyboard is the same as the distance from `B` to `A`, we can combine them together into one count;\n",
-    "I'll arbitrarily choose count them both under the alohabetically first one. I make a `Counter` of all two-letter segments, and `normalize` it so that the counts sum to 1 (and are thus probabilities)."
+    "I'll arbitrarily choose count them both under the alphabetically first one. I make a `Counter` of all two-letter segments, and `normalize` it so that the counts sum to 1 (and are thus probabilities)."
    ]
   },
   {


### PR DESCRIPTION
On `ipynb/Gesture Typing.ipynb`:

- Typo: `alohabetically` → `alphabetically`
- `longest 10 paths` → `10 longest paths` (clearer)