### PR TITLE
advent 2017 day 5 functions mutate the list

### DIFF
--- a/ipynb/Advent 2017.ipynb
+++ b/ipynb/Advent 2017.ipynb
@@ -836,6 +836,7 @@
    ],
    "source": [
     "def run(M):\n",
+    "    M = M[:]\n",
     "    pc = 0\n",
     "    for steps in count_from(1):\n",
     "        oldpc = pc\n",
@@ -890,6 +891,7 @@
    ],
    "source": [
     "def run2(M, verbose=False):\n",
+    "    M = M[:]\n",
     "    pc = 0\n",
     "    for steps in count_from(1):\n",
     "        oldpc = pc\n",


### PR DESCRIPTION
I think it would be good to create a copy of M within the run and run2 functions to avoid mutating the list that is passed in - it worked out fine since you created the input each time, but it would have gone wrong if you had only created it once.