### PR TITLE
Change module to modulo in Beal.ipynb

### DIFF
--- a/ipynb/Beal.ipynb
+++ b/ipynb/Beal.ipynb
@@ -819,7 +819,7 @@
     "\n",
     "# Faster Arithmetic (mod *p*)\n",
     "\n",
-    "Arithmetic is slow with integers that have thousands of digits. If we want to explore much further, we'll have to make the program more efficient. An obvious improvement would be to do all the arithmetic module some number $m$. Then we know:\n",
+    "Arithmetic is slow with integers that have thousands of digits. If we want to explore much further, we'll have to make the program more efficient. An obvious improvement would be to do all the arithmetic modulo some number $m$. Then we know:\n",
     "\n",
     "$$\\mbox{if} ~~ \n",
     "A^x + B^y = C^z\n",


### PR DESCRIPTION
There was a typo under Faster Arithmetic. Here is the issue: https://github.com/norvig/pytudes/issues/9