### PR TITLE
Advent 2017, day 5: speed up `run` function by avoiding repeated lookup

### DIFF
--- a/ipynb/Advent 2017.ipynb
+++ b/ipynb/Advent 2017.ipynb
@@ -857,8 +857,9 @@
    "source": [
     "def run(program):\n",
     "    memory = list(program)\n",
+    "    mlen = len(memory)\n",
     "    pc = steps = 0\n",
-    "    while pc in range(len(memory)):\n",
+    "    while 0 <= pc < mlen:\n",
     "        steps += 1\n",
     "        oldpc = pc\n",
     "        pc += memory[pc]\n",
@@ -912,8 +913,9 @@
    "source": [
     "def run2(program, verbose=False):\n",
     "    memory = list(program)\n",
+    "    mlen = len(memory)\n",
     "    pc = steps = 0\n",
-    "    while pc in range(len(memory)):\n",
+    "    while 0 <= pc < mlen:\n",
     "        steps += 1\n",
     "        oldpc = pc\n",
     "        pc += memory[pc]\n",


### PR DESCRIPTION
The statement
```
while pc in range(len(memory)):
   ...
```
performs a repeated lookup in the sequence `0, 1, 2, ..., 1073`, one for each iteration in the loop.

This can be made more efficient by simply checking whether the value of `pc` is between 0 and `len(memory)` (with an additional small speedup if the latter is pre-computed). Leads to a ca. 2.5x speedup (22.6 vs. 8.9 seconds on my laptop).