### PR TITLE
Some minor style/reference changes

### DIFF
--- a/ipynb/Economics.ipynb
+++ b/ipynb/Economics.ipynb
@@ -452,6 +452,7 @@
    "source": [
     "There are four parts to this output:\n",
     "\n",
+    "<div style='margin-left:2em'>",
     "**The printout:** For the starting population and for every 20,000 transactions along the way, we \n",
     "print the Gini coefficient and standard deviation of the population, and the wealths at five percentile points in the population: the 1%, 10%, 50% (median), 90% and 99% marks.\n",
     "\n",
@@ -461,11 +462,12 @@
     "\n",
     "**The ordered curves:** Here the initial (blue) and final (green) populations are sorted, and the curves show wealth versus ordinal number. The poorest actor (ordinal number 0) has wealth 0 in both the initial and final populations. The 2000th poorest actor (a bit below the median; at the 40th percentile) has wealth of almost 100 in the initial population, but only about 50 in the final population.\n",
     "\n",
-    "The results show that income inequality is increasing over time. How can you tell? Because  the Gini coefficient is increasing over time, the standard deviation is increasing, and the 1% and 10% marks are decreasing (the blue and olive lines are moving left as time increases) while the 90% and 99% marks are increasing (the aqua and purple lines are moving right as time increases).\n",
+    "</div>",
+    "The results show that income inequality is increasing over time. How can you tell? Because the Gini coefficient is increasing over time, the standard deviation is increasing, and in the Percentile Plots, the 1% and 10% marks are decreasing (the green and orange lines are moving left as time increases) while the 90% and 99% marks are increasing (the aqua and purple lines are moving right as time increases).\n",
     "\n",
     "\n",
     "\n",
-    "Would the population continue to change if we let the simulation run longer? It looks like only the 1% line is changing, the other lines remain pretty much in one place from about T=15,000 to T=25,000. This suggests that running the simulation longer would not have too much effect."
+    "Would the population continue to change if we let the simulation run longer? It looks like only the 1% line is changing, the other lines remain pretty much in one place from about T=15,000 to T=200,000. This suggests that running the simulation longer would not have too much effect."
    ]
   },
   {


### PR DESCRIPTION
I attempted the indent the description of the different graphs so that the following paragraph about the conclusions doesn't look like it's a second paragraph about the last graph. I'm not sure it will render correctly because github is not clever enough about displaying the preview for changes to an ipython notebook.

I also changed the colors described since they don't match what I see on github but it's possible there's a color rendering difference that's going to be hard to pin down.

Lastly, I changed the number on the description of the simulation to match what's shown in the tables and graphs.