### PR TITLE
Fix Typo : 4^9 instead of 9^4

### DIFF
--- a/ipynb/Countdown.ipynb
+++ b/ipynb/Countdown.ipynb
@@ -55,7 +55,7 @@
     "\n",
     "We'll start with a  simpler version of the puzzle: a countdown with no brackets.   \n",
     "\n",
-    "There are nine blanks,  each of which can be filled by one of four operators, so there are 9<sup>4</sup> = 262,144 possibilities, few enough that we can enumerate them all, using `itertools.product` to get tuples of operators, and then `str.format` to plug them into blanks, and then `eval` to evaluate the string:"
+    "There are nine blanks,  each of which can be filled by one of four operators, so there are 4<sup>9</sup> = 262,144 possibilities, few enough that we can enumerate them all, using `itertools.product` to get tuples of operators, and then `str.format` to plug them into blanks, and then `eval` to evaluate the string:"
    ]
   },
   {


### PR DESCRIPTION
Updated typo in Countdown.ipynb