### PR TITLE
Typo: ass -> as

### DIFF
--- a/ipynb/Advent-2020.ipynb
+++ b/ipynb/Advent-2020.ipynb
@@ -13,7 +13,7 @@
     "For each day from 1 to 25, I'll write **four pieces code** with the following format (and perhaps some auxiliary code). For example, on day 3:\n",
     "- `in3: List[str] = data(3)`: the day's input data, parsed into an appropriate form (here, a list of string lines).\n",
     "- `def day3_1(nums): ...   `: a function that takes the day's data as input and returns the answer for part 1.\n",
-    "- `def day3_2(nums): ...   `: a function that takes the day's data ass input and returns the answer for part 2.\n",
+    "- `def day3_2(nums): ...   `: a function that takes the day's data as input and returns the answer for part 2.\n",
     "- `do(3, 167, 736527114)   `: checks that `day3_1(in3) == 167` and `day3_2(in3) == 736527114`.\n",
     "\n",
     "(During development, I can say just `do(3)` to see the output without checking it.)\n",


### PR DESCRIPTION
There's a silly typo where it says "ass" instead of "as". Funny!