### PR TITLE
Update Probability.ipynb to clarify "Event".

### DIFF
--- a/ipynb/Probability.ipynb
+++ b/ipynb/Probability.ipynb
@@ -36,7 +36,7 @@
     "  The set of all possible outcomes for the trial. \n",
     "  <br>*For example,* `{1, 2, 3, 4, 5, 6}`.\n",
     "- **[Event](https://en.wikipedia.org/wiki/Event_(probability_theory%29):**\n",
-    "  A subset of outcomes that together have some property we are interested in.\n",
+    "  A subset of the sample space, a set of outcomes that together have some property we are interested in.\n",
     "  <br>*For example, the event \"even die roll\" is the set of outcomes* `{2, 4, 6}`. \n",
     "- **[Probability](https://en.wikipedia.org/wiki/Probability_theory):**\n",
     "  As Laplace said, the probability of an event with respect to a sample space is the \"number of favorable cases\" (outcomes from the sample space that are in the event) divided by the \"number of all the cases\" in the sample space (assuming \"nothing leads us to expect that any one of these cases should occur more than any other\"). Since this is a proper fraction, probability will always be a number between 0 (representing an impossible event) and 1 (representing a certain event).\n",


### PR DESCRIPTION
From the linked Wikipedia-article: "In probability theory, an event is a set of outcomes of an experiment (a subset of the sample space) to which a probability is assigned."

I believe this formulation is clearer than previous.