### PR TITLE
Fix typo: "vrei" → "vier"

### DIFF
--- a/ipynb/equilength-numbers.ipynb
+++ b/ipynb/equilength-numbers.ipynb
@@ -12,7 +12,7 @@
     "\n",
     "> ***Four is the only number that has the same amount of letters as its value.*** \n",
     "\n",
-    "We'll call \"*four*\" an **equilength number**. Languages other than English have different equilength numbers. In Italian there's \"tre\", in German  \"vrei\", in Spanish and Portuguese \"cinco\", and in Hanyu Pinyin Chinese \"èr\" and \"sān\". French does not have an equilength number. \n",
+    "We'll call \"*four*\" an **equilength number**. Languages other than English have different equilength numbers. In Italian there's \"tre\", in German  \"vier\", in Spanish and Portuguese \"cinco\", and in Hanyu Pinyin Chinese \"èr\" and \"sān\". French does not have an equilength number. \n",
     "\n",
     "There are also **equilength number expressions** such as \"two plus nine\": its value is 11 and there are 11 letters in the expression (spaces and hyphens don't count). What other integers besides 11 have equilength expressions? In English and in other languages? This notebook will partially answer these questions.  \n",
     "\n",


### PR DESCRIPTION
The German word for the number 4 is "vier", not "vrei".
("drei" stands for 3).
https://de.wikipedia.org/wiki/Vier