### PR TITLE
Wordle: Adjust expected_wins for bin size

### DIFF
--- a/ipynb/Wordle.ipynb
+++ b/ipynb/Wordle.ipynb
@@ -19,9 +19,9 @@
     "- Q: What first guess maximizes the number of **guaranteed wins** on the second guess?\n",
     "<br>A: `BRUTE` and `CHANT` guarantee you 40 wins (out of 2,315).\n",
     "- Q: What first guess maximizes the number of **expected wins** on the second guess?\n",
-    "<br>A: `FILET` gives you 57.5 expected wins  (out of 2,315). \n",
+    "<br>A: `TRACE` gives you 150 expected wins  (out of 2,315). \n",
     "\n",
-    "The probability of winning in two guesses is about 2%, so  the answer is: mostly lucky.\n",
+    "The probability of winning in two guesses is about 6.48%, so  the answer is: mostly lucky.\n",
     "\n",
     "# (2) What is a winning strategy I can memorize?\n",
     "\n",
@@ -176,15 +176,19 @@
     "\n",
     "def expected_wins(guess):\n",
     "    \"\"\"The expected number of wins on the 2nd guess (after `guess` first).\n",
-    "    With n words in a bin, you have a 1 / n chance of guessing the right one.\"\"\"\n",
-    "    return sum(1 / n for n in bin_sizes(guess))"
+    "    \n",
+    "    With n words in a bin, you have a 1 / n chance of guessing the right one.\n",
+    "    And the chance of ending up in a bin is n / 2315.\n",
+    "    So, the expected wins is, counter-intuitively, just number of possible bins.\n",
+    "    \"\"\"\n",
+    "    return len(bin_sizes(guess))"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Below we see that `BRUTE` and `CHANT` give the most guaranteed wins (bins of size 1), while `FILET` has the most expected wins (because it has many bins of size 2):"
+    "Below we see that `BRUTE` and `CHANT` give the most guaranteed wins (bins of size 1), while `TRACE` has the most expected wins (because it breaks down the answers into the most number of bins):"
    ]
   },
   {
@@ -224,16 +228,16 @@
     {
      "data": {
       "text/plain": [
-       "{'FILET': 57.49225359588394,\n",
-       " 'PARSE': 57.158766264952895,\n",
-       " 'DINER': 56.80471418211567,\n",
-       " 'BRUTE': 55.518562422003676,\n",
-       " 'METRO': 55.227427161935054,\n",
-       " 'TRUCE': 55.08315688051648,\n",
-       " 'TRACE': 54.9442057981406,\n",
-       " 'EARTH': 54.66697429572324,\n",
-       " 'TRIED': 54.52412463700236,\n",
-       " 'STALE': 54.34210156658472}"
+       "{'TRACE': 150,\n",
+       " 'CRATE': 148,\n",
+       " 'SLATE': 147,\n",
+       " 'PARSE': 146,\n",
+       " 'CRANE': 142,\n",
+       " 'STALE': 142,\n",
+       " 'HEART': 141,\n",
+       " 'LEAST': 140,\n",
+       " 'REACT': 140,\n",
+       " 'CATER': 139}"
       ]
      },
      "execution_count": 6,
@@ -249,7 +253,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Below we see that `MUMMY` is the worst first guess, by both metrics:"
+    "Below we see that `MUMMY` is one of the worst first guess, by both metrics:"
    ]
   },
   {
@@ -280,11 +284,7 @@
     {
      "data": {
       "text/plain": [
-       "{'MUMMY': 10.766462361593344,\n",
-       " 'QUEUE': 10.939009001096343,\n",
-       " 'QUEER': 12.173425009634647,\n",
-       " 'QUEEN': 12.2180304500002,\n",
-       " 'JAZZY': 13.38489636915653}"
+       "{'JAZZY': 31, 'FUZZY': 34, 'QUEUE': 35, 'FIZZY': 37, 'MUMMY': 37}"
       ]
      },
      "execution_count": 8,
@@ -534,8 +534,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 46.5 s, sys: 14.4 ms, total: 46.5 s\n",
-      "Wall time: 46.5 s\n"
+      "CPU times: user 33.8 s, sys: 89 ms, total: 33.9 s\n",
+      "Wall time: 33.9 s\n"
      ]
     }
    ],
@@ -634,8 +634,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 972 ms, sys: 5.41 ms, total: 977 ms\n",
-      "Wall time: 977 ms\n",
+      "CPU times: user 749 ms, sys: 8.64 ms, total: 758 ms\n",
+      "Wall time: 757 ms\n",
       "\n",
       "('DUTCH', 'WOVEN', 'SPRIG', 'BALMY') is a winner\n",
       "     bin counts: {1: 2117, 2: 88, 3: 6, 4: 1}\n",
@@ -760,7 +760,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [
     {
@@ -769,7 +769,7 @@
        "5.0315334773218146"
       ]
      },
-     "execution_count": 23,
+     "execution_count": 21,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -799,7 +799,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.9.9"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Let `M = 2315` (total number of possible answers) and `n = the size of bin for pattern n`.

In the original version

```
P(Guess in 2) = 1/M * Sum(Prob(Guess in 2 | Pattern))
                       = 1/M * Sum(1 / n) 
```

But, by [Total Probability](https://en.wikipedia.org/wiki/Law_of_total_probability), I believe the formula should be:

```
P(Guess in 2) = Sum(Prob(Guess in 2 | Pattern) * P(Pattern))
                       = Sum(1 / n * n / M)
                       = 1 / M * Sum(1)
```

The result is counter-intuitive to me, but the probability of a guess in 2 only depends on the number of (non-empty) bins/partitions that are created from a guess.

Credit to @fitzme for help verifying the math.
