### PR TITLE
fix: AOC 2023 day 23 part 2 off by one error in DFS

### DIFF
--- a/ipynb/Advent-2023.ipynb
+++ b/ipynb/Advent-2023.ipynb
@@ -4275,7 +4275,7 @@
     "                           for p2 in graph[p] if p2 not in seen], \n",
     "                          default=-inf)\n",
     "            seen.remove(p)\n",
-    "            return longest + 1\n",
+    "            return longest\n",
     "    return dfs(start)"
    ]
   },


### PR DESCRIPTION
hi @norvig !

I compared the results you got on the example input both with your initial attempt (154, the correct number) and with your optimized attempt (162). I also printed out the compressed graph, still on the example input, and saw it has 9 nodes. Now looking at your max_cost_graph_path function, the dfs func nested in it returns 0 if the end square has been reached else longest + 1. Here is the error and that explains why you are off by 8 (9 - 1 i.e. 9 nodes in total minus the end node). Same goes for the actual input.

Thanks for all the amazing solutions - they're always such great learning experiences! 🧩
