### PR TITLE
Fix return type and docstring in guess_row function

### DIFF
--- a/ipynb/Wordle.ipynb
+++ b/ipynb/Wordle.ipynb
@@ -294,8 +294,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def guess_row(guess) -> Tuple[Word, int, float, int]:\n",
-    "    \"\"\"A tuple of a (guess word, nuber of guaranteed wins, expected wins, maximum bin size).\"\"\"\n",
+    "def guess_row(guess) -> Tuple[Word, int, float]:\n",
+    "    \"\"\"A tuple of a (guess word, number of guaranteed wins, expected wins).\"\"\"\n",
     "    B = bins([guess], words)\n",
     "    return (guess, sum(len(bin) == 1 for bin in B), sum(1 / len(bin)  for bin in B))\n",
     "\n",


### PR DESCRIPTION
The `guess_row` function returns three things not four:
```Python
return (guess, sum(len(bin) == 1 for bin in B), sum(1 / len(bin) for bin in B))
```
You can see by inspection that "maximum bin size" is not returned. It would be implemented as:
```Python
max(len(bin) for bin in B)
```

This PR simply brings the return type annotation and docstring in line with the code.